### PR TITLE
Add gitpod config

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,8 @@
+tasks:
+  - init: 
+      echo "Replace me with a build script for the project."
+      cd ProucerConsumer
+      mkdir build && cd build
+      cmake .. -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+    command: echo "Replace me with something that should run on every start, or just
+      remove me entirely."

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/cosunae/cloudruption) 
+
 ![](images/logo.png)
 
 toy model to test messaging communication of services in the cloud


### PR DESCRIPTION
this commit adds support for Gitpod.io, a free automated
dev environment that makes contributing and generally working on GitHub
projects much easier. It allows anyone to start a ready-to-code dev
environment for any branch, issue and pull request with a single click.